### PR TITLE
Update link to Bazam-in-STRetch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ example, comparing two aligners, etc).
 
 You can see an advanced example of Bazam being used in the STRetch pipeline:
 
-https://github.com/Oshlack/STRetch/blob/feat-faster-bam-pipeline/pipelines/pipeline_stages.groovy#L101
+https://github.com/Oshlack/STRetch/blob/6f7c4805dcf1f8fb71c86d222ccff605a4ed6add/pipelines/pipeline_stages.groovy#L121
 
 


### PR DESCRIPTION
This had been merged and the old branch deleted so the link no longer worked. New link is to a specific release, so shouldn't go anywhere in the future.